### PR TITLE
Fix spiral chain offsets

### DIFF
--- a/problem1.py
+++ b/problem1.py
@@ -90,11 +90,14 @@ def generate_data() -> tuple[pd.DataFrame, pd.DataFrame]:
     # initialise all segments at t=0
     thetas[0] = theta_head0
     for seg in range(1, N):
-        s_i = s_head0 - (D_HEAD + (seg - 1) * D_BODY)
+        # Benches are located behind the head along the spiral, so their
+        # arc-length parameter is larger than the head's by the fixed
+        # bench spacing.
+        s_i = s_head0 + (D_HEAD + (seg - 1) * D_BODY)
         if s_i < 0:
             s_i = 0.0
         thetas[seg] = invert_length(s_i, thetas[seg - 1])
-    s_tail_rear = s_head0 - (D_HEAD + (N - 1) * D_BODY)
+    s_tail_rear = s_head0 + (D_HEAD + (N - 1) * D_BODY)
     if s_tail_rear < 0:
         s_tail_rear = 0.0
     thetas[N] = invert_length(s_tail_rear, thetas[N - 1])
@@ -109,7 +112,9 @@ def generate_data() -> tuple[pd.DataFrame, pd.DataFrame]:
         y[0, t_idx] = A * thetas[0] * np.sin(thetas[0])
 
         for seg in range(1, N):
-            s_i = s_head - (D_HEAD + (seg - 1) * D_BODY)
+            # Each subsequent bench follows the head at a fixed arc-length
+            # offset determined by the chain spacing.
+            s_i = s_head + (D_HEAD + (seg - 1) * D_BODY)
             # When the rear segments move past the spiral origin their
             # theoretical arc length becomes negative.  In reality they
             # would remain at the origin instead of continuing along the
@@ -120,7 +125,7 @@ def generate_data() -> tuple[pd.DataFrame, pd.DataFrame]:
             x[seg, t_idx] = A * thetas[seg] * np.cos(thetas[seg])
             y[seg, t_idx] = A * thetas[seg] * np.sin(thetas[seg])
 
-        s_tail_rear = s_head - (D_HEAD + (N - 1) * D_BODY)
+        s_tail_rear = s_head + (D_HEAD + (N - 1) * D_BODY)
         if s_tail_rear < 0:
             s_tail_rear = 0.0
         thetas[N] = invert_length(s_tail_rear, thetas[N])


### PR DESCRIPTION
## Summary
- correct bench offset sign when computing body segment positions
- document bench spacing

## Testing
- `python3 problem1.py`

------
https://chatgpt.com/codex/tasks/task_e_6879e45dc4748327aedbc297765d98fa